### PR TITLE
Improving error handling for postcode input

### DIFF
--- a/procurement/forms.py
+++ b/procurement/forms.py
@@ -24,7 +24,9 @@ class HomePageTenderForm(forms.Form):
         pc = self.cleaned_data["pc"]
         if pc != '':
             if not is_valid_postcode(pc):
-                self._errors["pc"] = "Invalid postcode or council name"
+                self._errors["pc"] = [
+                    "Invalid postcode or council name"
+                ]
             else:
                 mapit = MapIt()
 
@@ -37,7 +39,9 @@ class HomePageTenderForm(forms.Form):
                     InternalServerErrorException,
                     ForbiddenException,
                 ) as error:
-                    self._errors["pc"] = "Invalid postcode or council name"
+                    self._errors["pc"] = [
+                        "Invalid postcode or council name"
+                    ]
                 if gss_codes is not None:
                     return gss_codes
         return pc

--- a/procurement/settings.py
+++ b/procurement/settings.py
@@ -157,7 +157,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # django-bootstrap5 settings
 # https://django-bootstrap5.readthedocs.io/en/latest/settings.html
 BOOTSTRAP5 = {
-    "server_side_validation": False,
+    "set_placeholder": False,
+    "server_side_validation": True,
 }
 
 # data locations

--- a/procurement/static/css/_variables.scss
+++ b/procurement/static/css/_variables.scss
@@ -1,6 +1,7 @@
 // Color system
 
 $blue: #0263F3;
+$red: #dc3545;
 
 // Options
 
@@ -48,6 +49,18 @@ $form-label-font-weight: bold;
 $form-check-margin-bottom: 0.25rem;
 
 // Form validation
+
+$form-feedback-invalid-color: $red;
+$form-feedback-icon-invalid-color:  $form-feedback-invalid-color;
+$form-feedback-icon-invalid: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='#{$form-feedback-icon-invalid-color}'><circle cx='6' cy='6' r='4.5'/><path stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/><circle cx='6' cy='8.2' r='.6' fill='#{$form-feedback-icon-invalid-color}' stroke='none'/></svg>");
+
+// We don’t care about styling .is-valid fields, just .is-invalid ones.
+$form-validation-states: (
+  "invalid": (
+    "color": $form-feedback-invalid-color,
+    "icon": $form-feedback-icon-invalid
+  )
+);
 
 // Z-index master list
 

--- a/procurement/templates/procurement/includes/tender_filter.html
+++ b/procurement/templates/procurement/includes/tender_filter.html
@@ -1,21 +1,28 @@
 {% load django_bootstrap5 %}
 <form method="get">
 <div class="row">
-    <div class="col-sm-auto me-auto">
-        <label for="council-search" class="form-label">Search by postcode or council name</label>
-        <div class="error" >{{ filter.form.pc.errors }}</div>
-        <div class="search-input">
-            {% include 'procurement/icons/search.html' with classes='mr-2 flex-grow-0 flex-shrink-0' width='1.25em' height='1.25em' role='presentation' %}
-            {{ filter.form.pc }}
+    <div class="col-sm-6">
+        <div class="mb-3">
+            <label for="council-search" class="form-label">Search by postcode or council name</label>
+            <div class="search-input">
+                {% include 'procurement/icons/search.html' with classes='mr-2 flex-grow-0 flex-shrink-0' width='1.25em' height='1.25em' role='presentation' %}
+                {% bootstrap_field filter.form.pc show_label="skip" wrapper_class="" %}
+            </div>
+          {% for error in filter.form.pc.errors %}
+            <div class="invalid-feedback d-block" >{{ error }}</div>
+          {% endfor %}
         </div>
     </div>
 
-    <div class="col-sm-auto form-sort-by">
-        {% bootstrap_field filter.form.sort %}
-    </div>
-
-    <div class="col-sm-auto d-flex align-items-end">
-        <input class="btn btn-primary mb-3" type="submit" value="Filter">
+    <div class="col-sm-6 form-sort-by">
+        <div class="row align-items-end">
+            <div class="col-auto">
+                {% bootstrap_field filter.form.sort %}
+            </div>
+            <div class="col-auto">
+                <input class="btn btn-primary mb-3" type="submit" value="Filter">
+            </div>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
Using `{% bootstrap_field %}` gets us nice automatic error handling, and just feels like the right thing to do.

But for that to work, we need `server_side_validation` enabled, which brings with it the green "is-valid" styling on valid inputs, which looks weird when you’re submitting the search/filter form.

There is, annoyingly, no way to prevent django-bootstrap5 from generating these `.is-valid` classes, so instead we customise our Bootstrap settings to prevent the `.is-valid` style rules from ever being generated. This means duplicating a few more lines of `bootstrap/_variables.scss` into our own `/_variables.scss`, but I think it’s worth it to avoid the distracting `.is-valid` styling.

One annoyance I couldn’t avoid was the autocomplete library’s addition of an extra wrapper element around the text input, which breaks Bootstrap’s stupidly over-engineered CSS selector, and prevents error messages from being displayed.

As a result, despite using `{% bootstrap_field %}`, I still had to include my own error message output below, which kind of defeats the purpose.

It may be worth investigating whether our autocomplete library has an option to avoid injecting a wrapper element, but what we’ve got right now works in the meantime.

When a postcode error is displayed, it changes the height of the form row, meaning the submit button no longer lined up nicely. I’ve adjusted the form markup, to enable the button to line up with the other inputs regardless of whether an error is being displayed or not.

I made `filter.form.pc.errors` into a list, because that’s what the error handler in `bootstrap_field` expects. (If you use a string instead of a list, it explodes the string into many single-character error messages!)

Finally (!) I also `"set_placeholder": False` because we shouldn’t be using placeholders anywhere.

Part of #31.

![Screenshot 2022-10-26 at 13-38-49 Contract Countdown](https://user-images.githubusercontent.com/739624/198030025-ef22b09d-12b0-4fc9-b681-c4d334433d57.png)

![Screenshot 2022-10-26 at 13-38-42 Contract Countdown](https://user-images.githubusercontent.com/739624/198030067-ae396616-b562-4684-bb44-c7c255e1b2a3.png)
