### PR TITLE
Add error handling to 'exact council' field of email alert form.

### DIFF
--- a/procurement/templates/procurement/emails.html
+++ b/procurement/templates/procurement/emails.html
@@ -54,8 +54,13 @@
                     <label class="form-label visually-hidden" for="council_exact">Council name</label>
                     <div class="search-input">
                         <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 512 512" fill="currentColor" class="" role="presentation"><path d="M500.3 443.7l-119.7-119.7c27.22-40.41 40.65-90.9 33.46-144.7C401.8 87.79 326.8 13.32 235.2 1.723C99.01-15.51-15.51 99.01 1.724 235.2c11.6 91.64 86.08 166.7 177.6 178.9c53.8 7.189 104.3-6.236 144.7-33.46l119.7 119.7c15.62 15.62 40.95 15.62 56.57 0C515.9 484.7 515.9 459.3 500.3 443.7zM79.1 208c0-70.58 57.42-128 128-128s128 57.42 128 128c0 70.58-57.42 128-128 128S79.1 278.6 79.1 208z"/></svg>
-                        <input type="text" class="form-control" id="council_exact" name="council_exact">
+                        <input type="text" class="form-control{% if council_exact_error %} is-invalid {% endif %}" id="council_exact" name="council_exact">
                     </div>
+                    {% if council_exact_error %}
+                        <div class="invalid-feedback d-block">
+                            {{ council_exact_error }}
+                        </div>
+                    {% endif %}
                 </div>
                 {% endif %}
                 {% endfor %}

--- a/procurement/views.py
+++ b/procurement/views.py
@@ -126,6 +126,11 @@ class EmailAlertView(FilterView):
 
         if self.request.GET.get("region"):
             context["region_choice"] = self.request.GET.get("region")
+        
+        if self.request.GET.get("council_exact"):
+            council = self.request.GET.get("council_exact")
+            if not Council.objects.filter(name__iexact=council.lower()).exists():
+                context["council_exact_error"] = "Invalid postcode or council"
 
         return context
 


### PR DESCRIPTION
Fixes #31 

The best practises suggest that error handling shouldn't take place in the view, however, because this part of the form is hard-coded into the HTML rather than as part of a Form class associated with the filter, this is the only place this validation can occur without breaking the site.

Furthermore, ideally, when an error happens, the html template should announce it in a div with the class `"invalid-feedback"`, however this doesn't render (which is a known error in bootstrap 4, but I couldn't find much either way for bootstrap 5), which is why it has been mimicked and put inside an if/else.