### PR TITLE
Suppress .is-valid classes in django_bootstrap5

### DIFF
--- a/procurement/renderers.py
+++ b/procurement/renderers.py
@@ -1,0 +1,11 @@
+from django_bootstrap5.renderers import FieldRenderer
+
+
+# Defining a custom field renderer that doesn’t apply "is-valid"
+# success classes, even if the field is valid.
+class CustomFieldRenderer(FieldRenderer):
+    def get_server_side_validation_classes(self):
+        """Return CSS classes for server-side validation."""
+        if self.field_errors:
+            return "is-invalid"
+        return ""

--- a/procurement/settings.py
+++ b/procurement/settings.py
@@ -159,6 +159,9 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 BOOTSTRAP5 = {
     "set_placeholder": False,
     "server_side_validation": True,
+    "field_renderers": {
+        "default": "procurement.renderers.CustomFieldRenderer",
+    },
 }
 
 # data locations

--- a/procurement/static/css/_variables.scss
+++ b/procurement/static/css/_variables.scss
@@ -1,7 +1,6 @@
 // Color system
 
 $blue: #0263F3;
-$red: #dc3545;
 
 // Options
 
@@ -49,18 +48,6 @@ $form-label-font-weight: bold;
 $form-check-margin-bottom: 0.25rem;
 
 // Form validation
-
-$form-feedback-invalid-color: $red;
-$form-feedback-icon-invalid-color:  $form-feedback-invalid-color;
-$form-feedback-icon-invalid: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='#{$form-feedback-icon-invalid-color}'><circle cx='6' cy='6' r='4.5'/><path stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/><circle cx='6' cy='8.2' r='.6' fill='#{$form-feedback-icon-invalid-color}' stroke='none'/></svg>");
-
-// We don’t care about styling .is-valid fields, just .is-invalid ones.
-$form-validation-states: (
-  "invalid": (
-    "color": $form-feedback-invalid-color,
-    "icon": $form-feedback-icon-invalid
-  )
-);
 
 // Z-index master list
 


### PR DESCRIPTION
Ok, this feels like the _proper_ way to prevent `django_bootstrap5` from adding an `is-valid` class to valid form controls. Annoyed I didn’t think of this earlier.

<img width="765" alt="Screenshot 2022-10-28 at 09 51 44" src="https://user-images.githubusercontent.com/739624/198547153-d93cb160-6799-48a5-89b4-52ddc065be57.png"> 

Part of #31, and a follow-up to #32 and #39.