### PR TITLE
Fix error raised if somebody DOES enter a valid postcode.

### DIFF
--- a/procurement/forms.py
+++ b/procurement/forms.py
@@ -38,12 +38,13 @@ class PostcodeForm(forms.Form):
 class HomePagePostcodeAndCouncilForm(PostcodeForm):
     def clean_pc(self):
         pc = super().clean_pc()
-        council = Council.objects.filter(name__iexact=pc).first()
-        if council:
-            del self._errors["pc"]
-            return [council.gss_code]
-        else:
-            self._errors["pc"] = ["Invalid UK postcode or council."]
+        if type(pc) != list and pc != "":
+            council = Council.objects.filter(name__iexact=pc).first()
+            if council:
+                del self._errors["pc"]
+                return [council.gss_code]
+            else:
+                self._errors["pc"] = ["Invalid UK postcode or council."]
         return pc
         
 


### PR DESCRIPTION
When entering a valid postcode in the homepage search box, an error is raised because it searches for a council regardless of if it's already been caught as a postcode (which means that it's trying to filter based on a string, despite a list being given).

This has been fixed by just checking the type of the pc variable by the time it gets to the second `clean` function, which is meant for councils.